### PR TITLE
Update install instructions in readme to include NPM

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,7 +1,7 @@
 # Cursor Museum
 > A very brief history of pointing devices
 
-The source code for [cursormuseum.com](https://cursormuseum.com), a a silly dad joke turned into a website.
+The source code for [cursormuseum.com](https://cursormuseum.com), a silly dad joke turned into a website.
 
 https://github.com/terkelg/cursormuseum/assets/2302254/0cb70f6f-8e9a-40d2-a105-9e6a2acdb490
 
@@ -12,6 +12,11 @@ https://github.com/terkelg/cursormuseum/assets/2302254/0cb70f6f-8e9a-40d2-a105-9
 $ pnpm install
 ```
 
+or
+
+```
+$ npm install
+```
 
 ## Usage
 
@@ -19,8 +24,20 @@ $ pnpm install
 $ pnpm dev
 ```
 
+or
+
+```
+$ npm run dev
+```
+
 ```
 $ pnpm build
+```
+
+or
+
+```
+$ npm run build
 ```
 
 


### PR DESCRIPTION
Updates the `readme.md` file to include NPM installation and usage instructions alongside existing PNPM instructions.

- Adds `npm install` as an alternative to `pnpm install` for installation instructions.
- Includes `npm run dev` and `npm run build` as alternatives for running development and build scripts, respectively.
- Corrects a minor grammatical error in the project description.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/terkelg/cursormuseum?shareId=3c1ab7ab-0b04-4e2d-b727-6b317cb1ee89).